### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/commands/Media/Lyrics.ts
+++ b/src/commands/Media/Lyrics.ts
@@ -55,8 +55,8 @@ export default class Command extends BaseCommand {
         quoted: M.WAMessage,
         contextInfo: {
           externalAdReply: {
-            title: videos[0].title.substr(0, 30),
-            body: `Author : ${videos[0].author.name.substr(
+            title: videos[0].title.slice(0, 30),
+            body: `Author : ${videos[0].author.name.slice(
               0,
               20
             )}\n🌺 𝐒𝐇𝐔𝐍𝐀 🌺`,

--- a/src/commands/Media/Play.ts
+++ b/src/commands/Media/Play.ts
@@ -36,8 +36,8 @@ export default class Command extends BaseCommand {
         quoted: M.WAMessage,
         contextInfo: {
           externalAdReply: {
-            title: videos[0].title.substr(0, 30),
-            body: `Author : ${videos[0].author.name.substr(
+            title: videos[0].title.slice(0, 30),
+            body: `Author : ${videos[0].author.name.slice(
               0,
               20
             )}\n🌺 𝐒𝐇𝐔𝐍𝐀 🌺`,


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.